### PR TITLE
TrimmingPlugins editor: Added check for unvalid trimming values

### DIFF
--- a/plugins/es.upv.paella.TrimmingPlugins/trimming_editor.js
+++ b/plugins/es.upv.paella.TrimmingPlugins/trimming_editor.js
@@ -51,6 +51,10 @@ paella.plugins.TrimmingTrackPlugin = Class.create(paella.editor.MainTrackPlugin,
 	},
 	
 	onTrackChanged:function(id,start,end) {
+		//Checks if the trimming is valid (start >= 0 and end <= duration_of_the_video)
+		playerEnd = paella.player.videoContainer.trimEnd();
+		start = (start < 0)? 0 : start;
+		end = (end > playerEnd)? playerEnd : end;
 		this.trimmingTrack.s = start;
 		this.trimmingTrack.e = end;
 		this.parent(id,start,end);

--- a/plugins/es.upv.paella.TrimmingPlugins/trimming_editor.js
+++ b/plugins/es.upv.paella.TrimmingPlugins/trimming_editor.js
@@ -52,7 +52,7 @@ paella.plugins.TrimmingTrackPlugin = Class.create(paella.editor.MainTrackPlugin,
 	
 	onTrackChanged:function(id,start,end) {
 		//Checks if the trimming is valid (start >= 0 and end <= duration_of_the_video)
-		playerEnd = paella.player.videoContainer.trimEnd();
+		playerEnd = paella.player.videoContainer.duration(true);
 		start = (start < 0)? 0 : start;
 		end = (end > playerEnd)? playerEnd : end;
 		this.trimmingTrack.s = start;


### PR DESCRIPTION
The trimming could be set to an interval outside of the length of the video (Negative start and end bigger than the duration of the video).
- Added a check to onTrackChanged to check whether the values are valid before updating them.
