### PR TITLE
TTK-22565 - Show video thumbnail in paella player in Chrome

### DIFF
--- a/src/03_video_nodes.js
+++ b/src/03_video_nodes.js
@@ -757,7 +757,7 @@ Class ("paella.Html5Video", paella.VideoElementBase,{
 			get:function() { return This.domElement; }
 		});
 
-		this.video.preload = "auto";
+		this.video.preload = "metadata";
 		this.video.setAttribute("playsinline","");
 
 		function onProgress(event) {


### PR DESCRIPTION
Commit to fix the problem of showing the video thumbnail in Chrome
